### PR TITLE
Implement KeyRing::get_linked_keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linux-keyutils"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["landhb <landhb@users.noreply.github.com>"]
 description = """

--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -5,6 +5,7 @@ use core::ffi::CStr;
 
 /// Primary kernel identifier for a key or keyring.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(transparent)]
 pub struct KeySerialId(pub i32);
 
 /// Pre-defined key types the kernel understands. See `man 7 keyrings`.

--- a/src/key.rs
+++ b/src/key.rs
@@ -4,7 +4,7 @@ use alloc::string::String;
 use core::fmt;
 
 /// A key corresponding to a specific real ID.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Key(KeySerialId);
 
 impl fmt::Display for Key {

--- a/src/key.rs
+++ b/src/key.rs
@@ -57,14 +57,7 @@ impl Key {
     /// the caller search permission when searched for from the process
     /// keyrings (i.e., the key is possessed).
     pub fn read<T: AsMut<[u8]>>(&self, buffer: &mut T) -> Result<usize, KeyError> {
-        // TODO: alternate key types? Currenlty we only support KeyType::User
-        //
-        // The returned data will be processed for presentation according to
-        // the key type. For example, a keyring will  return  an  array  of
-        // key_serial_t entries  representing  the IDs of all the keys that
-        // are linked to it. The user key type will return its data as is.
-        // If a key type does not implement this function, the operation
-        // fails with the error EOPNOTSUPP.
+        // TODO: alternate key types? Currenlty we don't support KeyType::BigKey
         let len = ffi::keyctl!(
             KeyCtlOperation::Read,
             self.0.as_raw_id() as libc::c_ulong,

--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -123,7 +123,7 @@ impl KeyRing {
     /// The keyring must either grant the caller read permission, or grant
     /// the caller search permission.
     pub fn get_linked_keys(&self, max: usize) -> Result<Vec<Key>, KeyError> {
-        // Allocate a capacity of 200 keys
+        // Allocate the requested capacity
         let mut buffer = Vec::<KeySerialId>::with_capacity(max);
 
         // Perform the read


### PR DESCRIPTION
`KEYCTL_READ` is valid on keyrings as well and yields the list of key IDs linked to the ring.