### PR TITLE
Metadata and Links Additions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linux-keyutils"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 authors = ["landhb <landhb@users.noreply.github.com>"]
 description = """

--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -9,7 +9,7 @@ use crate::KeyError;
 pub struct KeySerialId(pub i32);
 
 /// Pre-defined key types the kernel understands. See `man 7 keyrings`.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum KeyType {
     /// Keyrings  are  special  key  types that may contain links to sequences of other
     /// keys of any type.

--- a/src/info.rs
+++ b/src/info.rs
@@ -82,7 +82,7 @@ impl KeyInfo {
             result.len() as _
         )? as usize;
 
-        // Construct the C-string
+        // Construct the CStr first to remove the null terminator
         let cs = CStr::from_bytes_with_nul(&result[..len]).or(Err(KeyError::InvalidDescription))?;
 
         // Construct the string from the resulting data ensuring utf8 compat

--- a/src/info.rs
+++ b/src/info.rs
@@ -1,5 +1,5 @@
 use crate::ffi::{self, KeyCtlOperation, KeySerialId};
-use crate::utils::String;
+use crate::utils::{CStr, String};
 use crate::{KeyError, KeyPermissions, KeyType};
 use alloc::string::ToString;
 use core::str::{self, FromStr};
@@ -82,8 +82,11 @@ impl KeyInfo {
             result.len() as _
         )? as usize;
 
+        // Construct the C-string
+        let cs = CStr::from_bytes_with_nul(&result[..len]).or(Err(KeyError::InvalidDescription))?;
+
         // Construct the string from the resulting data ensuring utf8 compat
-        let s = str::from_utf8(&result[..len]).or(Err(KeyError::InvalidDescription))?;
+        let s = cs.to_str().or(Err(KeyError::InvalidDescription))?;
         KeyInfo::from_str(s)
     }
 

--- a/src/info.rs
+++ b/src/info.rs
@@ -1,0 +1,114 @@
+use crate::ffi::{self, KeyCtlOperation, KeySerialId};
+use crate::utils::String;
+use crate::{KeyError, KeyPermissions, KeyType};
+use alloc::string::ToString;
+use core::str::{self, FromStr};
+
+/// Information about the given node/entry
+#[derive(Debug, Clone)]
+pub struct KeyInfo {
+    ktype: KeyType,
+    uid: u32,
+    gid: u32,
+    perm: KeyPermissions,
+    description: String,
+}
+
+impl FromStr for KeyInfo {
+    type Err = KeyError;
+
+    /// The returned string contains the following information about
+    /// the key:
+    ///
+    /// `type;uid;gid;perm;description`
+    ///
+    /// And is then parsed into a valid [KeyInfo] struct.
+    ///
+    /// In the above, type and description are strings, uid and gid are
+    /// decimal strings, and perm is a hexadecimal permissions mask.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Begin parsing
+        let mut iter = s.split(';');
+
+        // Parse type into KeyType
+        let ktype: KeyType = iter
+            .next()
+            .and_then(|v| v.try_into().ok())
+            .ok_or(KeyError::InvalidDescription)?;
+
+        // Parse the UID
+        let uid = iter
+            .next()
+            .and_then(|v| v.parse().ok())
+            .ok_or(KeyError::InvalidDescription)?;
+
+        // Parse the GID
+        let gid = iter
+            .next()
+            .and_then(|v| v.parse().ok())
+            .ok_or(KeyError::InvalidDescription)?;
+
+        // Parse the permissions
+        let perms: u32 = iter
+            .next()
+            .and_then(|v| u32::from_str_radix(v, 16).ok())
+            .ok_or(KeyError::InvalidDescription)?;
+
+        // Copy the actual description
+        let description = iter.next().ok_or(KeyError::InvalidDescription)?.to_string();
+
+        // Create the description
+        Ok(Self {
+            ktype,
+            uid,
+            gid,
+            perm: KeyPermissions::from_u32(perms),
+            description,
+        })
+    }
+}
+
+impl KeyInfo {
+    /// Internal method to derive information from an
+    /// arbitrary node based on ID alone.
+    pub(crate) fn from_id(id: KeySerialId) -> Result<Self, KeyError> {
+        let mut result = alloc::vec![0u8; 512];
+
+        // Obtain the description from the kernel
+        let len = ffi::keyctl!(
+            KeyCtlOperation::Describe,
+            id.as_raw_id() as libc::c_ulong,
+            result.as_mut_ptr() as _,
+            result.len() as _
+        )? as usize;
+
+        // Construct the string from the resulting data ensuring utf8 compat
+        let s = str::from_utf8(&result[..len]).or(Err(KeyError::InvalidDescription))?;
+        KeyInfo::from_str(s)
+    }
+
+    /// The type of this entry
+    pub fn get_type(&self) -> KeyType {
+        self.ktype
+    }
+
+    /// The owning UID of this entry
+    pub fn get_uid(&self) -> u32 {
+        self.uid
+    }
+
+    /// The owning GID of this entry
+    pub fn get_gid(&self) -> u32 {
+        self.gid
+    }
+
+    /// The current permissions of this entry
+    pub fn get_perms(&self) -> KeyPermissions {
+        self.perm
+    }
+
+    /// The description for this entry
+    pub fn get_description(&self) -> &str {
+        &self.description
+    }
+}

--- a/src/key.rs
+++ b/src/key.rs
@@ -3,6 +3,32 @@ use crate::{KeyError, KeyPermissions, Metadata};
 use core::fmt;
 
 /// A key corresponding to a specific real ID.
+///
+/// Generally you will either create or obtain a Key via the [KeyRing] interface.
+/// Since keys must be linked with a keyring to be valid.
+///
+/// For example:
+///
+/// ```
+/// use linux_keyutils::{Key, KeyRing, KeyRingIdentifier, KeyError};
+/// use zeroize::Zeroize;
+///
+/// // Name of my program's key
+/// const KEYNAME: &'static str = "my-process-key";
+///
+/// // Locate the key in the process keyring and update the secret
+/// fn update_secret<T: AsRef<[u8]> + Zeroize>(data: &T) -> Result<(), KeyError> {
+///     // Get the current process keyring
+///     let ring = KeyRing::from_special_id(KeyRingIdentifier::Process, false)?;
+///
+///     // Locate the key we previously created
+///     let key = ring.search(KEYNAME)?;
+///
+///     // Change the data it contains
+///     key.update(data)?;
+///     Ok(())
+/// }
+/// ```
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Key(KeySerialId);
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -191,11 +191,12 @@ mod tests {
         // Create the key
         let key = ring.add_key("my-info-key", secret).unwrap();
 
-        let euid = unsafe { libc::geteuid() };
+        // Obtain and verify the info
         let info = key.info().unwrap();
-
         assert_eq!(info.get_type(), KeyType::User);
-        assert_eq!(info.get_uid(), euid);
+        assert_eq!(info.get_uid(), unsafe { libc::geteuid() });
+        assert_eq!(info.get_gid(), unsafe { libc::getegid() });
+        assert_eq!(info.get_description(), "my-info-key");
 
         // Cleanup
         key.invalidate().unwrap()

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,5 +1,5 @@
 use crate::ffi::{self, KeyCtlOperation, KeySerialId};
-use crate::{KeyError, KeyInfo, KeyPermissions};
+use crate::{KeyError, KeyPermissions, Metadata};
 use core::fmt;
 
 /// A key corresponding to a specific real ID.
@@ -8,7 +8,7 @@ pub struct Key(KeySerialId);
 
 impl fmt::Display for Key {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let info = self.info().map_err(|_| fmt::Error::default())?;
+        let info = self.metadata().map_err(|_| fmt::Error::default())?;
         write!(f, "Key({:?})", info)
     }
 }
@@ -27,8 +27,8 @@ impl Key {
     /// Obtain information describing the attributes of this key.
     ///
     /// The key must grant the caller view permission.
-    pub fn info(&self) -> Result<KeyInfo, KeyError> {
-        KeyInfo::from_id(self.0)
+    pub fn metadata(&self) -> Result<Metadata, KeyError> {
+        Metadata::from_id(self.0)
     }
 
     /// Read the payload data of a key.
@@ -182,7 +182,7 @@ mod tests {
     use zeroize::Zeroizing;
 
     #[test]
-    fn test_info() {
+    fn test_metadata() {
         let secret = "Test Data";
 
         // Obtain the default User keyring
@@ -192,7 +192,7 @@ mod tests {
         let key = ring.add_key("my-info-key", secret).unwrap();
 
         // Obtain and verify the info
-        let info = key.info().unwrap();
+        let info = key.metadata().unwrap();
         assert_eq!(info.get_type(), KeyType::User);
         assert_eq!(info.get_uid(), unsafe { libc::geteuid() });
         assert_eq!(info.get_gid(), unsafe { libc::getegid() });

--- a/src/key.rs
+++ b/src/key.rs
@@ -4,8 +4,8 @@ use core::fmt;
 
 /// A key corresponding to a specific real ID.
 ///
-/// Generally you will either create or obtain a Key via the [KeyRing] interface.
-/// Since keys must be linked with a keyring to be valid.
+/// Generally you will either create or obtain a Key via the [KeyRing](crate::KeyRing)
+/// interface. Since keys must be linked with a keyring to be valid.
 ///
 /// For example:
 ///
@@ -95,7 +95,7 @@ impl Key {
     /// If the caller doesn't have the CAP_SYS_ADMIN capability, it can change
     /// permissions only only for the keys it owns. (More precisely: the caller's
     /// filesystem UID must match the UID of the key.)
-    pub fn set_perm(&self, perm: KeyPermissions) -> Result<(), KeyError> {
+    pub fn set_perms(&self, perm: KeyPermissions) -> Result<(), KeyError> {
         _ = ffi::keyctl!(
             KeyCtlOperation::SetPerm,
             self.0.as_raw_id() as libc::c_ulong,
@@ -250,7 +250,7 @@ mod tests {
         perms.set_group_perms(Permission::ALL);
 
         // Set the permissions
-        key.set_perm(perms).unwrap();
+        key.set_perms(perms).unwrap();
 
         // Read the secret and verify it matches
         let len = key.read(&mut buf).unwrap();

--- a/src/key.rs
+++ b/src/key.rs
@@ -196,6 +196,7 @@ mod tests {
         assert_eq!(info.get_type(), KeyType::User);
         assert_eq!(info.get_uid(), unsafe { libc::geteuid() });
         assert_eq!(info.get_gid(), unsafe { libc::getegid() });
+        assert_eq!(info.get_perms().bits(), 0x3F010000);
         assert_eq!(info.get_description(), "my-info-key");
 
         // Cleanup

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,26 +1,15 @@
 use crate::ffi::{self, KeyCtlOperation, KeySerialId};
-use crate::utils::String;
-use crate::{KeyError, KeyPermissions, KeyType};
+use crate::{KeyError, KeyInfo, KeyPermissions};
 use core::fmt;
 
 /// A key corresponding to a specific real ID.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Key(KeySerialId);
 
-/// An entry description
-#[derive(Debug, Clone)]
-pub struct Description {
-    ktype: KeyType,
-    uid: u16,
-    gid: u16,
-    perm: KeyPermissions,
-    description: String,
-}
-
 impl fmt::Display for Key {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let description = self.description().map_err(|_| fmt::Error::default())?;
-        write!(f, "Key({})", description.description)
+        let info = self.info().map_err(|_| fmt::Error::default())?;
+        write!(f, "Key({:?})", info)
     }
 }
 
@@ -35,55 +24,11 @@ impl Key {
         self.0
     }
 
-    /// Obtain a string describing the attributes of a specified key.
+    /// Obtain information describing the attributes of this key.
     ///
     /// The key must grant the caller view permission.
-    ///
-    /// The returned string contains the following information about
-    /// the key:
-    ///
-    /// `type;uid;gid;perm;description`
-    ///
-    /// In the above, type and description are strings, uid and gid are
-    /// decimal strings, and perm is a hexadecimal permissions mask.
-    pub fn description(&self) -> Result<Description, KeyError> {
-        let mut result = alloc::vec![0u8; 512];
-
-        // Obtain the description from the kernel
-        let len = ffi::keyctl!(
-            KeyCtlOperation::Describe,
-            self.0.as_raw_id() as libc::c_ulong,
-            result.as_mut_ptr() as _,
-            result.len() as _
-        )? as usize;
-
-        // Construct the string from the resulting data ensuring utf8 compat
-        let s = core::str::from_utf8(&result[..len]).or(Err(KeyError::InvalidDescription))?;
-        println!("{:?}", s);
-        // Begin parsing
-        let mut iter = s.split(';');
-
-        // Create the description
-        Ok(Description {
-            ktype: iter
-                .next()
-                .and_then(|v| v.try_into().ok())
-                .ok_or(KeyError::InvalidDescription)?,
-            uid: iter
-                .next()
-                .and_then(|v| v.parse().ok())
-                .ok_or(KeyError::InvalidDescription)?,
-            gid: iter
-                .next()
-                .and_then(|v| v.parse().ok())
-                .ok_or(KeyError::InvalidDescription)?,
-            perm: KeyPermissions::from_u32(
-                iter.next()
-                    .and_then(|v| u32::from_str_radix(v, 16).ok())
-                    .ok_or(KeyError::InvalidDescription)?,
-            ),
-            description: iter.next().ok_or(KeyError::InvalidDescription)?.to_string(),
-        })
+    pub fn info(&self) -> Result<KeyInfo, KeyError> {
+        KeyInfo::from_id(self.0)
     }
 
     /// Read the payload data of a key.
@@ -233,8 +178,28 @@ impl Key {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{KeyRing, KeyRingIdentifier, Permission};
+    use crate::{KeyRing, KeyRingIdentifier, KeyType, Permission};
     use zeroize::Zeroizing;
+
+    #[test]
+    fn test_info() {
+        let secret = "Test Data";
+
+        // Obtain the default User keyring
+        let ring = KeyRing::from_special_id(KeyRingIdentifier::Session, false).unwrap();
+
+        // Create the key
+        let key = ring.add_key("my-info-key", secret).unwrap();
+
+        let euid = unsafe { libc::geteuid() };
+        let info = key.info().unwrap();
+
+        assert_eq!(info.get_type(), KeyType::User);
+        assert_eq!(info.get_uid(), euid);
+
+        // Cleanup
+        key.invalidate().unwrap()
+    }
 
     #[test]
     fn test_user_keyring_add_key() {

--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -1,13 +1,11 @@
 use crate::ffi::{self, KeyCtlOperation};
+use crate::utils::{CStr, CString, Vec};
 use crate::{Key, KeyError, KeyRingIdentifier, KeySerialId, KeyType};
-use alloc::ffi::CString;
-use alloc::vec::Vec;
 use core::convert::TryInto;
-use core::ffi::CStr;
 
 /// Interface to perform keyring operations. Used to locate, create,
 /// search, add, and link/unlink keys to & from keyrings.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct KeyRing {
     id: KeySerialId,
 }
@@ -215,7 +213,7 @@ mod test {
         assert!(user_ring.id.as_raw_id() > 0);
 
         let user_perm_ring = KeyRing::get_persistent(KeyRingIdentifier::User).unwrap();
-        assert_ne!(user_ring.id.as_raw_id(), user_perm_ring.id.as_raw_id());
+        assert_ne!(user_ring, user_perm_ring);
     }
 
     #[test]

--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -260,7 +260,7 @@ mod test {
             .build();
 
         // Enforce perms
-        key.set_perm(perms).unwrap();
+        key.set_perms(perms).unwrap();
 
         // Search should succeed
         let result = ring.search("test_search").unwrap();

--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -300,16 +300,16 @@ mod test {
 
         // Assert that the key is in the ring
         assert!(items.len() > 0);
-        assert!(items.contains(key));
+        assert!(items.contains(&key));
 
         // Use the alternate reference to the key
-        let key_ref = items.get(key).unwrap().as_key().unwrap();
+        let key_ref = items.get(&key).unwrap().as_key().unwrap();
 
         // Invalidate the key
         key_ref.invalidate().unwrap();
 
         // Assert that the key is no longer on the ring
         let items = ring.get_links(200).unwrap();
-        assert!(!items.contains(key));
+        assert!(!items.contains(&key));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,8 +95,12 @@ mod key;
 pub use key::Key;
 
 // Information about nodes (either keys or keyrings)
-mod info;
-pub use info::KeyInfo;
+mod metadata;
+pub use metadata::Metadata;
+
+// Nodes in a ring/tree
+mod links;
+pub use links::LinkNode;
 
 // Expose KeyPermissions API
 mod permissions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!         .build();
 //!
 //!     // Perform manipulations on the key such as setting permissions
-//!     key.set_perm(perms)?;
+//!     key.set_perms(perms)?;
 //!
 //!     // Or setting a timeout for how long the key should exist
 //!     key.set_timeout(300)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,11 +54,27 @@
 //! }
 //! ```
 #![cfg_attr(not(feature = "std"), no_std)]
-#![deny(warnings)]
+//#![deny(warnings)]
 
-// no_std CStr/CString support stabilized in Rust 1.64.0
 // CString requires alloc however
 extern crate alloc;
+
+// Use the std-lib when available
+#[cfg(feature = "std")]
+mod utils {
+    pub use std::ffi::{CStr, CString};
+    pub use std::string::String;
+    pub use std::vec::Vec;
+}
+
+// #![no_std] CStr/CString support stabilized in Rust 1.64.0
+#[cfg(not(feature = "std"))]
+mod utils {
+    pub use alloc::ffi::CString;
+    pub use alloc::string::String;
+    pub use alloc::vec::Vec;
+    pub use core::ffi::CStr;
+}
 
 // Internal FFI for raw syscalls
 mod ffi;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,10 @@ pub use keyring::KeyRing;
 mod key;
 pub use key::Key;
 
+// Information about nodes (either keys or keyrings)
+mod info;
+pub use info::KeyInfo;
+
 // Expose KeyPermissions API
 mod permissions;
 pub use permissions::{KeyPermissions, KeyPermissionsBuilder, Permission};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub use metadata::Metadata;
 
 // Nodes in a ring/tree
 mod links;
-pub use links::LinkNode;
+pub use links::{LinkNode, Links};
 
 // Expose KeyPermissions API
 mod permissions;

--- a/src/links.rs
+++ b/src/links.rs
@@ -1,5 +1,9 @@
+//! Helper types for iterating over keyring entries
+//!
+use crate::utils::Vec;
 use crate::{Key, KeyError, KeyRing, KeySerialId, KeyType, Metadata};
 use core::cmp::PartialEq;
+use core::ops::Deref;
 
 /// An item/node linked to a ring. Both keys and other keyrings
 /// can be linked to a particular keyring.
@@ -9,17 +13,9 @@ pub enum LinkNode {
     Key(Key),
 }
 
-impl LinkNode {
-    pub(crate) fn from_id(id: KeySerialId) -> Result<Self, KeyError> {
-        let metadata = Metadata::from_id(id)?;
-        let node = match metadata.get_type() {
-            KeyType::KeyRing => Self::KeyRing(KeyRing::from_id(id)),
-            KeyType::User => Self::Key(Key::from_id(id)),
-            _ => return Err(KeyError::OperationNotSupported),
-        };
-        Ok(node)
-    }
-}
+/// A collection of LinkNodes, returned from [KeyRing::get_links]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Links(Vec<LinkNode>);
 
 impl PartialEq<Key> for LinkNode {
     fn eq(&self, other: &Key) -> bool {
@@ -42,5 +38,78 @@ impl PartialEq<KeyRing> for LinkNode {
 impl PartialEq<KeyRing> for &LinkNode {
     fn eq(&self, other: &KeyRing) -> bool {
         matches!(self, LinkNode::KeyRing(x) if x == other)
+    }
+}
+
+impl LinkNode {
+    /// Internal method to construct a LinkNode from a raw ID
+    pub(crate) fn from_id(id: KeySerialId) -> Result<Self, KeyError> {
+        let metadata = Metadata::from_id(id)?;
+        let node = match metadata.get_type() {
+            KeyType::KeyRing => Self::KeyRing(KeyRing::from_id(id)),
+            KeyType::User => Self::Key(Key::from_id(id)),
+            _ => return Err(KeyError::OperationNotSupported),
+        };
+        Ok(node)
+    }
+
+    /// Attempt to convert this LinkNode to a Key
+    ///
+    /// Returns the key if the entry is a Key, None otherwise.
+    pub fn as_key(&self) -> Option<Key> {
+        match self {
+            Self::Key(inner) => Some(*inner),
+            _ => None,
+        }
+    }
+
+    /// Attempt to convert this LinkNode to a KeyRing
+    ///
+    /// Returns the ring if the entry is a KeyRing, None otherwise.
+    pub fn as_ring(&self) -> Option<KeyRing> {
+        match self {
+            Self::KeyRing(inner) => Some(*inner),
+            _ => None,
+        }
+    }
+}
+
+impl Deref for Links {
+    type Target = Vec<LinkNode>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl FromIterator<LinkNode> for Links {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = LinkNode>,
+    {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl Links {
+    /// Internal constructor to abstract the list of objects
+    pub fn new(inner: Vec<LinkNode>) -> Self {
+        Self(inner)
+    }
+
+    /// Obtain the entry with the provided ID/Key/Keyring
+    pub fn get<T>(&self, entry: T) -> Option<&LinkNode>
+    where
+        LinkNode: PartialEq<T>,
+    {
+        self.0.iter().find(|v| **v == entry)
+    }
+
+    /// Check if the list contains the provided ID/Key/Keyring
+    pub fn contains<T>(&self, entry: T) -> bool
+    where
+        LinkNode: PartialEq<T>,
+    {
+        self.0.iter().any(|v| *v == entry)
     }
 }

--- a/src/links.rs
+++ b/src/links.rs
@@ -14,6 +14,24 @@ pub enum LinkNode {
 }
 
 /// A collection of LinkNodes, returned from [KeyRing::get_links]
+///
+/// For example:
+///
+/// ```
+/// use linux_keyutils::{Key, KeyRing, KeyRingIdentifier, KeyError};
+///
+/// // Test if a particular Key is linked to the user session KeyRing
+/// fn is_linked_to_user_session(key: &Key) -> Result<bool, KeyError> {
+///     // Get the  keyring
+///     let ring = KeyRing::from_special_id(KeyRingIdentifier::UserSession, false)?;
+///
+///     // Locate all the links
+///     let links = ring.get_links(200)?;
+///
+///     // Determine if the key is linked to the ring
+///     Ok(links.contains(key))
+/// }
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Links(Vec<LinkNode>);
 
@@ -98,18 +116,18 @@ impl Links {
     }
 
     /// Obtain the entry with the provided ID/Key/Keyring
-    pub fn get<T>(&self, entry: T) -> Option<&LinkNode>
+    pub fn get<T>(&self, entry: &T) -> Option<&LinkNode>
     where
         LinkNode: PartialEq<T>,
     {
-        self.0.iter().find(|v| **v == entry)
+        self.0.iter().find(|v| *v == entry)
     }
 
     /// Check if the list contains the provided ID/Key/Keyring
-    pub fn contains<T>(&self, entry: T) -> bool
+    pub fn contains<T>(&self, entry: &T) -> bool
     where
         LinkNode: PartialEq<T>,
     {
-        self.0.iter().any(|v| *v == entry)
+        self.0.iter().any(|v| v == entry)
     }
 }

--- a/src/links.rs
+++ b/src/links.rs
@@ -1,0 +1,60 @@
+use crate::{Key, KeyError, KeyRing, KeySerialId, KeyType, Metadata};
+use core::cmp::PartialEq;
+
+/// An item/node linked to a ring. Both keys and other keyrings
+/// can be linked to a particular keyring.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum LinkNode {
+    KeyRing(KeyRing),
+    Key(Key),
+}
+
+impl LinkNode {
+    pub(crate) fn from_id(id: KeySerialId) -> Result<Self, KeyError> {
+        let metadata = Metadata::from_id(id)?;
+        let node = match metadata.get_type() {
+            KeyType::KeyRing => Self::KeyRing(KeyRing::from_id(id)),
+            KeyType::User => Self::Key(Key::from_id(id)),
+            _ => return Err(KeyError::OperationNotSupported),
+        };
+        Ok(node)
+    }
+}
+
+impl PartialEq<Key> for LinkNode {
+    fn eq(&self, other: &Key) -> bool {
+        match self {
+            Self::KeyRing(_) => false,
+            Self::Key(x) if x == other => true,
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq<Key> for &LinkNode {
+    fn eq(&self, other: &Key) -> bool {
+        match &self {
+            LinkNode::KeyRing(_) => false,
+            LinkNode::Key(x) if x == other => true,
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq<KeyRing> for LinkNode {
+    fn eq(&self, other: &KeyRing) -> bool {
+        match self {
+            LinkNode::KeyRing(x) if x == other => true,
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq<KeyRing> for &LinkNode {
+    fn eq(&self, other: &KeyRing) -> bool {
+        match &self {
+            LinkNode::KeyRing(x) if x == other => true,
+            _ => false,
+        }
+    }
+}

--- a/src/links.rs
+++ b/src/links.rs
@@ -23,38 +23,24 @@ impl LinkNode {
 
 impl PartialEq<Key> for LinkNode {
     fn eq(&self, other: &Key) -> bool {
-        match self {
-            Self::KeyRing(_) => false,
-            Self::Key(x) if x == other => true,
-            _ => false,
-        }
+        matches!(self, LinkNode::Key(x) if x == other)
     }
 }
 
 impl PartialEq<Key> for &LinkNode {
     fn eq(&self, other: &Key) -> bool {
-        match &self {
-            LinkNode::KeyRing(_) => false,
-            LinkNode::Key(x) if x == other => true,
-            _ => false,
-        }
+        matches!(self, LinkNode::Key(x) if x == other)
     }
 }
 
 impl PartialEq<KeyRing> for LinkNode {
     fn eq(&self, other: &KeyRing) -> bool {
-        match self {
-            LinkNode::KeyRing(x) if x == other => true,
-            _ => false,
-        }
+        matches!(self, LinkNode::KeyRing(x) if x == other)
     }
 }
 
 impl PartialEq<KeyRing> for &LinkNode {
     fn eq(&self, other: &KeyRing) -> bool {
-        match &self {
-            LinkNode::KeyRing(x) if x == other => true,
-            _ => false,
-        }
+        matches!(self, LinkNode::KeyRing(x) if x == other)
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -4,7 +4,8 @@ use crate::{KeyError, KeyPermissions, KeyType};
 use alloc::string::ToString;
 use core::str::{self, FromStr};
 
-/// Information about the given node/entry
+/// Information about the given node/entry.
+/// Returned by [Key::metadata] or [KeyRing::metadata]
 #[derive(Debug, Clone)]
 pub struct Metadata {
     ktype: KeyType,
@@ -22,7 +23,7 @@ impl FromStr for Metadata {
     ///
     /// `type;uid;gid;perm;description`
     ///
-    /// And is then parsed into a valid [KeyInfo] struct.
+    /// And is then parsed into a valid [Metadata] struct.
     ///
     /// In the above, type and description are strings, uid and gid are
     /// decimal strings, and perm is a hexadecimal permissions mask.

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -5,7 +5,8 @@ use alloc::string::ToString;
 use core::str::{self, FromStr};
 
 /// Information about the given node/entry.
-/// Returned by [Key::metadata] or [KeyRing::metadata]
+/// Returned by [Key::metadata](crate::Key::metadata)
+/// or [KeyRing::metadata](crate::KeyRing::metadata)
 #[derive(Debug, Clone)]
 pub struct Metadata {
     ktype: KeyType,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -6,7 +6,7 @@ use core::str::{self, FromStr};
 
 /// Information about the given node/entry
 #[derive(Debug, Clone)]
-pub struct KeyInfo {
+pub struct Metadata {
     ktype: KeyType,
     uid: u32,
     gid: u32,
@@ -14,7 +14,7 @@ pub struct KeyInfo {
     description: String,
 }
 
-impl FromStr for KeyInfo {
+impl FromStr for Metadata {
     type Err = KeyError;
 
     /// The returned string contains the following information about
@@ -68,7 +68,7 @@ impl FromStr for KeyInfo {
     }
 }
 
-impl KeyInfo {
+impl Metadata {
     /// Internal method to derive information from an
     /// arbitrary node based on ID alone.
     pub(crate) fn from_id(id: KeySerialId) -> Result<Self, KeyError> {
@@ -87,7 +87,7 @@ impl KeyInfo {
 
         // Construct the string from the resulting data ensuring utf8 compat
         let s = cs.to_str().or(Err(KeyError::InvalidDescription))?;
-        KeyInfo::from_str(s)
+        Self::from_str(s)
     }
 
     /// The type of this entry

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -2,7 +2,7 @@
 //! permissions defined in keyutils.h
 use bitflags::bitflags;
 
-/// Construct key permissions
+/// Construct key permissions for use with [Key::set_perm]
 ///
 /// Usage:
 ///
@@ -33,6 +33,7 @@ pub struct KeyPermissionsBuilder(KeyPermissions);
 
 bitflags! {
     /// Pre-defined bit-flags to construct permissions easily.
+    #[repr(transparent)]
     pub struct Permission: u8 {
         /// Allows viewing a key's attributes
         const VIEW = 0x1;

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -13,6 +13,7 @@ use bitflags::bitflags;
 /// perms.set_user_perms(Permission::ALL);
 /// perms.set_group_perms(Permission::VIEW);
 /// ```
+#[derive(Debug, Copy, Clone)]
 pub struct KeyPermissions(u32);
 
 /// Construct key permissions with the builder pattern.
@@ -27,6 +28,7 @@ pub struct KeyPermissions(u32);
 ///             .group(Permission::VIEW)
 ///             .build();
 /// ```
+#[derive(Debug, Copy, Clone)]
 pub struct KeyPermissionsBuilder(KeyPermissions);
 
 bitflags! {

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -2,7 +2,8 @@
 //! permissions defined in keyutils.h
 use bitflags::bitflags;
 
-/// Construct key permissions for use with [Key::set_perm]
+/// Construct key permissions for use with [Key::set_perms](crate::Key::set_perms)
+/// or returned by [Metadata::get_perms](crate::Metadata::get_perms).
 ///
 /// Usage:
 ///


### PR DESCRIPTION
Add `Metadata` and `Key::metadata` + `KeyRing::metadata` API for all node types.

Add `KeyRing::get_links` which returns a `Links` structure containing `LinkNode`s.