### PR TITLE
Update dependencies to new semver versions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -91,8 +91,6 @@ jobs:
       matrix:
         channel: [stable]
         target:
-          - mips64-unknown-linux-muslabi64
-          - mips-unknown-linux-musl
           - aarch64-unknown-linux-musl
           - arm-unknown-linux-musleabihf
           - i686-unknown-linux-musl

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: XAMPPRocky/get-github-release@v1
         id: cross
         with:
-          owner: rust-embedded
+          owner: cross-rs
           repo: cross
           matches: ${{ matrix.platform }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ required-features = ["std"]
 
 [dependencies]
 libc = {version = "0.2.132", default-features = false}
-bitflags = "1.3"
+bitflags = "2.4"
 
 [dev-dependencies]
 zeroize = "1.5.7"
-clap = {version = "3.2.22", default-features = false, features = ["std", "derive"]}
+clap = {version = "4.4.11", default-features = false, features = ["std", "derive"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "Apache-2.0 OR MIT"
 
 [features]
 default = []
-std = []
+std = ["bitflags/std"]
 
 [[example]]
 name = "keyctl"
@@ -23,7 +23,7 @@ required-features = ["std"]
 
 [dependencies]
 libc = {version = "0.2.132", default-features = false}
-bitflags = "2.4"
+bitflags = {version = "2.4", default-features = false}
 
 [dev-dependencies]
 zeroize = "1.5.7"

--- a/src/key.rs
+++ b/src/key.rs
@@ -35,7 +35,7 @@ pub struct Key(KeySerialId);
 
 impl fmt::Display for Key {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let info = self.metadata().map_err(|_| fmt::Error::default())?;
+        let info = self.metadata().map_err(|_| fmt::Error)?;
         write!(f, "Key({:?})", info)
     }
 }


### PR DESCRIPTION
Currently I get two different versions of bitflags pulled into my project. One of two users of the old major version is linux-keyutils. This PR updates the major version to the current one to reduce this.

No actual code changes were needed (I guess the breaking changes didn't affect this crate.)

Please also made a new (minor) release on crates.io with these changes.