### PR TITLE
Derive common traits on KeyRingIdentifier

### DIFF
--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -30,6 +30,7 @@ pub enum KeyType {
 
 /// Special identifiers for default keyrings. See `man 7 keyrings`.
 #[allow(dead_code)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum KeyRingIdentifier {
     /// Key ID for thread-specific keyring
     Thread = -1,


### PR DESCRIPTION
Missing some basic traits on this type bit me on a project I've been working on. Just one example: I couldn't check whether a KeyRingIdentifier passed into a function was equal to some other one.