### PR TITLE
Add methods for linking a keyring to another keyring

### DIFF
--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -195,6 +195,71 @@ impl KeyRing {
         Ok(())
     }
 
+    /// Link another keyring to this keyring.
+    ///
+    /// Behaves similarly to link_key, but links a KeyRing instead. The caller
+    /// must have link permission on the keyring being added as a link, and
+    /// write permission on this keyring.
+    pub fn link_keyring(&self, keyring: KeyRing) -> Result<(), KeyError> {
+        _ = ffi::keyctl!(
+            KeyCtlOperation::Link,
+            keyring.id.as_raw_id() as libc::c_ulong,
+            self.id.as_raw_id() as libc::c_ulong
+        )?;
+        Ok(())
+    }
+
+    /// Unlink another keyring from this keyring.
+    ///
+    /// Behaves similarly to unlink_key, but unlinks a KeyRing instead. The
+    /// caller must have write permission on the keyring to remove links
+    /// from it.
+    pub fn unlink_keyring(&self, keyring: KeyRing) -> Result<(), KeyError> {
+        _ = ffi::keyctl!(
+            KeyCtlOperation::Unlink,
+            keyring.id.as_raw_id() as libc::c_ulong,
+            self.id.as_raw_id() as libc::c_ulong
+        )?;
+        Ok(())
+    }
+
+    /// Link a default keyring from this keyring.
+    ///
+    /// This method does the same thing as link_keyring, but links one of the
+    /// special keyrings defined by the system. This is useful when you
+    /// don't want to have to open a keyring before linking it.
+    ///
+    /// The caller must have link permissions on the added keyring, and write
+    /// permission on this keyring. In addition, this method will return
+    /// KeyError::KeyDoesNotExist if the target keyring has not yet been
+    /// created.
+    pub fn link_keyring_id(&self, keyringid: KeyRingIdentifier) -> Result<(), KeyError> {
+        _ = ffi::keyctl!(
+            KeyCtlOperation::Link,
+            keyringid as libc::c_ulong,
+            self.id.as_raw_id() as libc::c_ulong
+        )?;
+        Ok(())
+    }
+
+    /// Unlink a default keyring from this keyring.
+    ///
+    /// This method does the same thing as unlink_keyring, but unlinks one of
+    /// the special keyrings defined by the system. This is useful when you
+    /// don't want to have to open a keyring before unlinking it.
+    ///
+    /// The caller must have write permission on this keyring. In addition, this
+    /// method will return KeyError::KeyDoesNotExist if the target keyring has
+    /// not yet been created.
+    pub fn unlink_keyring_id(&self, keyringid: KeyRingIdentifier) -> Result<(), KeyError> {
+        _ = ffi::keyctl!(
+            KeyCtlOperation::Unlink,
+            keyringid as libc::c_ulong,
+            self.id.as_raw_id() as libc::c_ulong
+        )?;
+        Ok(())
+    }
+
     /// Clear the contents of (i.e., unlink all keys from) this keyring.
     ///
     /// The caller must have write permission on the keyring.


### PR DESCRIPTION
This is an important keyctl operation that can have implications on whether a key is readable and shows up in Search operations.

It may not be immediately be apparent that this is a supported operation when calling KEYCTL_LINK, you have to dig through the docs to find this.

man 7 keyrings:

> As previously mentioned, keyrings are a special type of key that
contains links to other keys (which may include other keyrings). Keys may be linked to by multiple keyrings.